### PR TITLE
Add Dockerfile with multiple Python versions

### DIFF
--- a/multi/Dockerfile
+++ b/multi/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+
+RUN apt update \
+    && apt install -y --no-install-recommends python2.7 python3.6 python3.7 tox \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This container is required for test purposes.
Python versions:
 - 2.7
 - 3.6
 - 3.7