### PR TITLE
add default k8s IP addr range

### DIFF
--- a/2.7/config/nginx/nginx.conf
+++ b/2.7/config/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
     default_type  application/octet-stream;
     # recursive real ip
     set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 100.0.0.0/8;
     set_real_ip_from 172.0.0.0/8;
     set_real_ip_from 192.0.0.0/8;
     set_real_ip_from 127.0.0.1;

--- a/3.6/config/nginx/nginx.conf
+++ b/3.6/config/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
     default_type  application/octet-stream;
     # recursive real ip
     set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 100.0.0.0/8;
     set_real_ip_from 172.0.0.0/8;
     set_real_ip_from 192.0.0.0/8;
     set_real_ip_from 127.0.0.1;

--- a/3.7/config/nginx/nginx.conf
+++ b/3.7/config/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
     default_type  application/octet-stream;
     # recursive real ip
     set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 100.0.0.0/8;
     set_real_ip_from 172.0.0.0/8;
     set_real_ip_from 192.0.0.0/8;
     set_real_ip_from 127.0.0.1;


### PR DESCRIPTION
To log the client IP addr in microservices running in k8S, default k8s IP addr range needs to be added into nginx.conf