### PR TITLE
`&& apt-get install -qq -y binutils libproj-dev gdal-bin` to support faster CI run on 2.1

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -43,6 +43,7 @@ RUN groupadd "${APP_GRP}" \
 &&  rm -f /etc/nginx/conf.d/* /etc/nginx/sites-enabled/* \
 &&  pip install --no-cache-dir -U -r /tmp/requirements.txt \
 &&  poetry config settings.virtualenvs.create false \
+&&  apt-get install -qq -y binutils libproj-dev gdal-bin
 &&  apt-get clean \
 &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd "${APP_GRP}" \
 &&  rm -f /etc/nginx/conf.d/* /etc/nginx/sites-enabled/* \
 &&  pip install --no-cache-dir -U -r /tmp/requirements.txt \
 &&  poetry config settings.virtualenvs.create false \
-&&  apt-get install -qq -y binutils libproj-dev gdal-bin
+&&  apt-get install -qq -y binutils libproj-dev gdal-bin \
 &&  apt-get clean \
 &&  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
following the discussion on https://inspectorioinc.slack.com/archives/CD8BMBSGG/p1551250023085400