### PR TITLE
Revert "Install supervisor via pip to use the latest version"

### DIFF
--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -31,7 +31,7 @@ RUN groupadd "${APP_GRP}" \
 &&  apt-get -qq -y update \
 &&  apt-get install -qq -o Dpkg::Options::="--force-confold" \
                     -y --no-install-recommends \
-                    curl jq vim-nox openssh-client \
+                    supervisor curl jq vim-nox openssh-client \
                     moreutils gettext-base locales tzdata lsb-release \
 &&  curl -sSL http://nginx.org/keys/nginx_signing.key | apt-key add - \
 &&  echo "deb http://nginx.org/packages/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ $(lsb_release -cs) nginx" > /etc/apt/sources.list.d/nginx.list \

--- a/3.8/requirements.txt
+++ b/3.8/requirements.txt
@@ -5,4 +5,3 @@ newrelic
 gunicorn
 uwsgi
 uwsgitop
-supervisor


### PR DESCRIPTION
This reverts commit 2d88b8f7d49ea5f5598eaab68a29919b1ef3d5a3.